### PR TITLE
fix path to yml in core/docker/readme

### DIFF
--- a/core/docker/README.md
+++ b/core/docker/README.md
@@ -52,7 +52,7 @@ Additional `docker-compose` files are available for extra environment configurat
 The below command specifies the three `docker-compose` files that need to be executed for the development configuration
 
 ```bash
-docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.config.yml up -d
+docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f importer/docker-compose.config.yml up -d
 ```
 
 The below command specifies the two `docker-compose` files that need to be executed for a production-like configuration


### PR DESCRIPTION
Based on what I see in `compose.sh` ([see line 11](https://github.com/openhie/instant/blob/master/core/docker/compose.sh#L11)), I believe the path to `docker-compose.config.yml` needs to be fixed per this PR.