### PR TITLE
Add the mysql table case insensitivity option

### DIFF
--- a/core/docker/compose.sh
+++ b/core/docker/compose.sh
@@ -8,6 +8,10 @@ if [ "$1" == "init" ]; then
     # Set up the replica set
     "$composeFilePath"/initiateReplicaSet.sh
 
+    docker create --name hapi-mysql-helper -v hapi-mysql-config:/conf.d busybox
+    docker cp "$composeFilePath"/importer/volume/mysql.cnf hapi-mysql-helper:/conf.d/mysql.cnf
+    docker rm hapi-mysql-helper
+
     docker-compose -p instant -f "$composeFilePath"/docker-compose.yml -f "$composeFilePath"/docker-compose.dev.yml -f "$composeFilePath"/importer/docker-compose.config.yml up -d
 elif [ "$1" == "up" ]; then
     docker-compose -p instant -f "$composeFilePath"/docker-compose-mongo.yml up -d

--- a/core/docker/docker-compose.dev.yml
+++ b/core/docker/docker-compose.dev.yml
@@ -9,7 +9,7 @@ services:
 
   fhir:
     container_name: hapi-fhir
-    image: hapiproject/hapi:v5.4.1
+    image: hapiproject/hapi:latest
     ports:
       - "3447:8080"
 

--- a/core/docker/docker-compose.yml
+++ b/core/docker/docker-compose.yml
@@ -27,7 +27,7 @@ services:
 
   fhir:
     container_name: hapi-fhir
-    image: hapiproject/hapi:v5.4.1
+    image: hapiproject/hapi:latest
     environment:
       - spring.datasource.url=jdbc:mysql://mysql:3306/hapi
       - spring.datasource.username=admin
@@ -55,8 +55,11 @@ services:
       MYSQL_ROOT_PASSWORD: 'instant101'
     volumes:
       - 'hapi-mysql:/var/lib/mysql'
+      - 'hapi-mysql-config:/etc/mysql/conf.d'
 
 volumes:
   hapi-mysql:
+  hapi-mysql-config:
+    external: true
   instant:
     external: true

--- a/core/docker/importer/volume/mysql.cnf
+++ b/core/docker/importer/volume/mysql.cnf
@@ -1,0 +1,3 @@
+[mysqld]
+
+lower_case_table_names=1

--- a/core/kubernetes/main/hapi-fhir/hapi-fhir-mysql-deployment.yaml
+++ b/core/kubernetes/main/hapi-fhir/hapi-fhir-mysql-deployment.yaml
@@ -33,8 +33,13 @@ spec:
           volumeMounts:
             - name: core-hapi-fhir-mysql-volume
               mountPath: /var/lib/mysql
+            - name: core-hapi-fhir-mysql-config-map
+              mountPath: /etc/mysql/conf.d
       restartPolicy: Always
       volumes:
         - name: core-hapi-fhir-mysql-volume
           persistentVolumeClaim:
             claimName: hapi-fhir-mysql-volume-claim
+        - name: core-hapi-fhir-mysql-config-map
+          configMap:
+            name: core-hapi-fhir-mysql-configmap

--- a/core/kubernetes/main/hapi-fhir/hapi-fhir-server-deployment.yaml
+++ b/core/kubernetes/main/hapi-fhir/hapi-fhir-server-deployment.yaml
@@ -22,7 +22,7 @@ spec:
           command: ['sh', '-c', 'until telnet hapi-fhir-mysql-service 3306; do echo MySQL not running yet; sleep 10; done;']
       containers:
         - name: hapi-fhir-server
-          image: hapiproject/hapi:v5.2.1
+          image: hapiproject/hapi:latest
           env:
             - name: spring.datasource.url
               value: jdbc:mysql://hapi-fhir-mysql-service:3306/hapi

--- a/core/kubernetes/main/hapi-fhir/volume/mysql.cnf
+++ b/core/kubernetes/main/hapi-fhir/volume/mysql.cnf
@@ -1,0 +1,3 @@
+[mysqld]
+
+lower_case_table_names=1

--- a/core/kubernetes/main/kustomization.yaml
+++ b/core/kubernetes/main/kustomization.yaml
@@ -2,6 +2,9 @@ configMapGenerator:
   - name: core-openhim-core-configmap
     files:
       - ./openhim/volume/openhim-core/development.json
+  - name: core-hapi-fhir-mysql-configmap
+    files:
+      - ./hapi-fhir/volume/mysql.cnf
 
 resources:
   # volumes


### PR DESCRIPTION
Upgrading HAPI FHIR from v5.2.1 to v5.4.2 came with changes to the table
names - from uppercase to lowercase. MySQL by default is case sensitive.
Adding the MySQL conf file in removes the case sensitivity and allows
HAPI FHIR to read tables without case issues.

OHIE-521