### PR TITLE
DIO-71 Add docker service command in dev script

### DIFF
--- a/core/docker/docker-compose.dev.yml
+++ b/core/docker/docker-compose.dev.yml
@@ -6,6 +6,7 @@ services:
     container_name: mongo-1
     ports:
       - "27017:27017"
+    command: ['--replSet', 'mongo-set', '--wiredTigerCacheSizeGB', '0.5']
 
   fhir:
     container_name: hapi-fhir


### PR DESCRIPTION
This command did not apply in the dev script which meant that the
mongo-1 container had the default start up command unlike mongo-2 and
mongo-3. On `up` the replica set initialise step doesn't run (on
mongo-1) therefore this instance remains disconnected from the others

DIO-79