### PR TITLE
Ohie 500 jvm tuning hapi fhir reduce memory usage

### DIFF
--- a/core/docker/docker-compose.yml
+++ b/core/docker/docker-compose.yml
@@ -43,7 +43,7 @@ services:
         target: /instant
     depends_on:
       - mysql
-
+    mem_limit: 2g
   mysql:
     container_name: hapi-mysql
     image: mysql:5.7

--- a/core/kubernetes/main/hapi-fhir/hapi-fhir-server-deployment.yaml
+++ b/core/kubernetes/main/hapi-fhir/hapi-fhir-server-deployment.yaml
@@ -23,6 +23,7 @@ spec:
       containers:
         - name: hapi-fhir-server
           image: hapiproject/hapi:latest
+          mem_limit: 2g
           env:
             - name: spring.datasource.url
               value: jdbc:mysql://hapi-fhir-mysql-service:3306/hapi

--- a/core/kubernetes/main/hapi-fhir/hapi-fhir-server-deployment.yaml
+++ b/core/kubernetes/main/hapi-fhir/hapi-fhir-server-deployment.yaml
@@ -23,7 +23,9 @@ spec:
       containers:
         - name: hapi-fhir-server
           image: hapiproject/hapi:latest
-          mem_limit: 2g
+          resources:
+            limits:
+              memory: "2Gi"
           env:
             - name: spring.datasource.url
               value: jdbc:mysql://hapi-fhir-mysql-service:3306/hapi


### PR DESCRIPTION
# If applied, this commit will:
Limit HAPI FHIR containers to use a maximum of 2GB

# Explain why this change is being made
To prevent cost overruns with containers

# Provide links to any relevant tickets, articles or other resources
Ticket number is OHIE-500.
links are: https://kubernetes.io/docs/tasks/configure-pod-container/assign-memory-resource/ 
https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
https://linuxhint.com/docker_compose_memory_limits/