### PR TITLE
Support --only flag to only operate on specified packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,13 @@ Each command also takes a list of package IDs to operate on. If this is left out
 
 E.g only run `core` package: `yarn docker:instant init -t k8s core`
 
+### Supported options
+
+Instant supports a few options after the main command in the form: `instant <main_command> [options] [package-ids]` e.g. `yarn docker:instant init -t k8s`
+
+* --target, -t : specify a target to deploy to, defaults to docker. Allowed values: docker, kubernetes, k8s
+* --only, -o : if supplied only the specified packages will be acted upon in the order they are provided, ignoring dependencies
+
 ## Custom packages
 
 To add a custom package to your instant instance use the following flag

--- a/instant.ts
+++ b/instant.ts
@@ -140,6 +140,11 @@ const orderPackageIds = (allPackages, chosenPackageIds) => {
           name: 'target',
           alias: 't',
           defaultValue: 'docker'
+        },
+        {
+          name: 'only',
+          alias: 'o',
+          type: Boolean
         }
       ],
       { argv, stopAtFirstUnknown: true }
@@ -160,8 +165,10 @@ const orderPackageIds = (allPackages, chosenPackageIds) => {
       chosenPackageIds = Object.keys(allPackages)
     }
 
-    // Order the packages such that the dependencies are instantiated first
-    chosenPackageIds = orderPackageIds(allPackages, chosenPackageIds)
+    if (!mainOptions.only) {
+      // Order the packages such that the dependencies are instantiated first
+      chosenPackageIds = orderPackageIds(allPackages, chosenPackageIds)
+    }
 
     if (['destroy', 'down'].includes(main.command)) {
       chosenPackageIds.reverse()


### PR DESCRIPTION
This flag ignores resolving deps and acts on the specified packages only, in thge order they are provided.