### PR TITLE
Correct the openhim url

### DIFF
--- a/elastic-pipeline/docker/docker-compose.yml
+++ b/elastic-pipeline/docker/docker-compose.yml
@@ -14,6 +14,10 @@ services:
     environment:
       - GET_URL=http://hapi-fhir:8080/fhir
       - POST_URL=http://logstash:5055/fhir
+      - TRUST_SELF_SIGNED=true
+      - OPENHIM_PASSWORD=instant101
+      - OPENHIM_USERNAME=root@openhim.org
+      - OPENHIM_URL=https://openhim-core:8080
 
 volumes:
   logstash-pipeline:


### PR DESCRIPTION
The url for the fhir extractor to register on the openhim was incorrect

DIO-106