### PR TITLE
Switch hapi fhir from mysql to postgres

### DIFF
--- a/core/docker/compose.sh
+++ b/core/docker/compose.sh
@@ -17,10 +17,6 @@ if [ "$1" == "init" ]; then
     # Set up the replica set
     "$composeFilePath"/initiateReplicaSet.sh
 
-    docker create --name hapi-mysql-helper -v hapi-mysql-config:/conf.d busybox
-    docker cp "$composeFilePath"/importer/volume/mysql.cnf hapi-mysql-helper:/conf.d/mysql.cnf
-    docker rm hapi-mysql-helper
-
     PASSWORD_SALT=$(openssl rand -hex 16)
     PASSWORD_HASH=$(echo -n $PASSWORD_SALT${OPENHIM_ROOT_PASSWORD-instant101} | openssl sha512 | awk '{print $2}')
 

--- a/core/docker/docker-compose.dev.yml
+++ b/core/docker/docker-compose.dev.yml
@@ -18,6 +18,6 @@ services:
     ports:
       - "3447:8080"
 
-  hapi-mysql:
+  hapi-db:
     ports:
-      - "3306:3306"
+      - "5432:5432"

--- a/core/docker/docker-compose.yml
+++ b/core/docker/docker-compose.yml
@@ -22,11 +22,11 @@ services:
     container_name: hapi-fhir
     image: hapiproject/hapi:v5.5.1
     environment:
-      - spring.datasource.url=jdbc:mysql://hapi-mysql:3306/hapi
+      - spring.datasource.url=jdbc:postgresql://hapi-db:5432/hapi
       - spring.datasource.username=admin
       - spring.datasource.password=instant101
-      - spring.datasource.driverClassName=com.mysql.jdbc.Driver
-      - spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL5InnoDBDialect
+      - spring.datasource.driverClassName=org.postgresql.Driver
+      - spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQL95Dialect
       - hapi.fhir.allow_external_references=true
       - hapi.fhir.bulk_export_enabled=true
       - JAVA_TOOL_OPTIONS=-Xmx2g
@@ -36,26 +36,21 @@ services:
         source: instant
         target: /instant
     depends_on:
-      - hapi-mysql
+      - hapi-db
     restart: unless-stopped
 
-  hapi-mysql:
-    container_name: hapi-mysql
-    image: mysql:5.7
-    command: mysqld --character-set-server=utf8 --collation-server=utf8_general_ci
+  hapi-db:
+    container_name: hapi-db
+    image: postgres:14.1
     environment:
-      MYSQL_DATABASE: 'hapi'
-      MYSQL_USER: 'admin'
-      MYSQL_PASSWORD: 'instant101'
-      MYSQL_ROOT_PASSWORD: 'instant101'
+      POSTGRES_PASSWORD: instant101
+      POSTGRES_USER: admin
+      POSTGRES_DB: hapi
     volumes:
-      - 'hapi-mysql-volume:/var/lib/mysql'
-      - 'hapi-mysql-config:/etc/mysql/conf.d'
+      - 'hapi-db-volume:/var/lib/postgresql/data'
     restart: unless-stopped
 
 volumes:
-  hapi-mysql-volume:
-  hapi-mysql-config:
-    external: true
+  hapi-db-volume:
   instant:
     external: true

--- a/core/docker/importer/volume/mysql.cnf
+++ b/core/docker/importer/volume/mysql.cnf
@@ -1,3 +1,0 @@
-[mysqld]
-
-lower_case_table_names=1


### PR DESCRIPTION
Postgres is faster and recommended for production deployments. It's best to use this from the start.