### PR TITLE
Fix default target launcher

### DIFF
--- a/goinstant/docker.go
+++ b/goinstant/docker.go
@@ -113,6 +113,11 @@ func extractCommands(startupCommands []string) (environmentVariables []string, d
 	if len(environmentVariables) > 0 {
 		environmentVariables = getEnvironmentVariables(environmentVariables, []string{"-e=", "--env-file="})
 	}
+
+	if targetLauncher == "" {
+		targetLauncher = cfg.DefaultTargetLauncher
+	}
+
 	return
 }
 


### PR DESCRIPTION
The default target launcher wasn't being set when running in non-interactive mode, this will set it to the default that's in the config file.
PLAT-75