### PR TITLE
Plat 69 instant volume update fix

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,7 +10,19 @@ goinstant
 
 # Docs
 docs
+kubernetes.md
+README.md
 
 # Dependency directories
 node_modules/
 .editorconfig
+.prettierrc.json
+cov
+
+# Git stuff
+.git
+.github
+.gitignore
+
+# env files
+.env*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM node:fermium-buster AS base
 
+RUN mkdir packages
 WORKDIR /instant
 
 # install curl
@@ -38,3 +39,4 @@ ENTRYPOINT [ "yarn", "instant" ]
 FROM base as instant-build
 # Add default instant OpenHIE packages
 ADD . .
+RUN cp -r . ../packages

--- a/core/docker/docker-compose.yml
+++ b/core/docker/docker-compose.yml
@@ -31,10 +31,6 @@ services:
       - hapi.fhir.bulk_export_enabled=true
       - JAVA_TOOL_OPTIONS=-Xmx2g
       - CATALINA_OPTS=-Xmx2g
-    volumes:
-      - type: volume
-        source: instant
-        target: /instant
     depends_on:
       - hapi-db
     restart: unless-stopped
@@ -52,5 +48,3 @@ services:
 
 volumes:
   hapi-db-volume:
-  instant:
-    external: true

--- a/instant.ts
+++ b/instant.ts
@@ -3,6 +3,7 @@
 import * as commandLineArgs from 'command-line-args'
 import * as glob from 'glob'
 import * as fs from 'fs'
+import * as rimraf from 'rimraf'
 import * as child from 'child_process'
 import * as util from 'util'
 import * as path from 'path'
@@ -133,6 +134,8 @@ const logPackageDetails = (packageInfo: PackageInfo) => {
 
 // Main script execution
 ;(async () => {
+  await updateInstantVolume()
+
   const allPackages = getInstantOHIEPackages()
   console.log(
     `Found ${Object.keys(allPackages).length} packages: ${Object.values(
@@ -288,3 +291,14 @@ const logPackageDetails = (packageInfo: PackageInfo) => {
     }
   }
 })()
+
+function updateInstantVolume() {
+  fs.readdirSync('.', { withFileTypes: true })
+    .filter(item => item.isDirectory())
+    .forEach(item => {
+      if (item.name !== 'node_modules' && fs.existsSync('../packages')) {
+        rimraf.sync(item.name)
+      }
+    })
+    return exec('cp -r ../packages/. .')
+}

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "command-line-args": "^5.1.1",
     "env-cmd": "^10.1.0",
     "glob": "^7.1.6",
+    "rimraf": "^3.0.2",
     "ts-node": "^8.10.2",
     "typescript": "^3.9.6"
   },
@@ -32,6 +33,7 @@
   },
   "devDependencies": {
     "@cucumber/cucumber": "^7.0.0",
+    "@types/rimraf": "^3.0.2",
     "axios": "^0.21.4",
     "chai": "^4.2.0",
     "prettier": "^2.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -186,6 +186,14 @@
   resolved "https://registry.yarnpkg.com/@types/command-line-args/-/command-line-args-5.0.0.tgz#484e704d20dbb8754a8f091eee45cdd22bcff28c"
   integrity sha512-4eOPXyn5DmP64MCMF8ePDvdlvlzt2a+F8ZaVjqmh2yFCpGjc1kI3kGnCFYX9SCsGTjQcWIyVZ86IHCEyjy/MNg==
 
+"@types/glob@*":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.2.0.tgz#bc1b5bf3aa92f25bd5dd39f35c57361bdce5b2eb"
+  integrity sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==
+  dependencies:
+    "@types/minimatch" "*"
+    "@types/node" "*"
+
 "@types/glob@^7.1.3":
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.3.tgz#e6ba80f36b7daad2c685acd9266382e68985c183"
@@ -213,6 +221,14 @@
   version "13.13.50"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-13.13.50.tgz#bc8ebf70c392a98ffdba7aab9b46989ea96c1c62"
   integrity sha512-y7kkh+hX/0jZNxMyBR/6asG0QMSaPSzgeVK63dhWHl4QAXCQB8lExXmzLL6SzmOgKHydtawpMnNhlDbv7DXPEA==
+
+"@types/rimraf@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@types/rimraf/-/rimraf-3.0.2.tgz#a63d175b331748e5220ad48c901d7bbf1f44eef8"
+  integrity sha512-F3OznnSLAUxFrCEu/L5PY8+ny8DtcFRjx7fZZ9bycvXRi3KPTRS9HOitGZwvPg0juRhXFWIeKX58cnX5YqLohQ==
+  dependencies:
+    "@types/glob" "*"
+    "@types/node" "*"
 
 "@types/uuid@^8.3.0":
   version "8.3.0"
@@ -728,7 +744,7 @@ resolve@^1.19.0:
     is-core-module "^2.2.0"
     path-parse "^1.0.6"
 
-rimraf@^3.0.0:
+rimraf@^3.0.0, rimraf@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==


### PR DESCRIPTION
@rcrichton , we should evaluate if we want the instant volume to hang around in the first place. As it stands, this PR will update package data when doing an up command.