### PR TITLE
Add some base error handling so we don't swallow top level thrown errors

### DIFF
--- a/instant.ts
+++ b/instant.ts
@@ -132,7 +132,7 @@ const logPackageDetails = (packageInfo: PackageInfo) => {
 }
 
 // Main script execution
-;(async () => {
+const main = async () => {
   const allPackages = getInstantOHIEPackages()
   console.log(
     `Found ${Object.keys(allPackages).length} packages: ${Object.values(
@@ -287,4 +287,13 @@ const logPackageDetails = (packageInfo: PackageInfo) => {
       await runTests(features)
     }
   }
-})()
+}
+
+// Entry point IIFE with base error handling
+;(async () => {
+  try {
+  await main()
+} catch (error) {
+  console.log(error)
+  process.exit(1)
+}})()


### PR DESCRIPTION
This change will cause the Go CLI to raise an error if the instant.ts script encounters an error. We should discuss if this is appropriate or if the CLI should rather handle the error and print out something to the user.