### PR TITLE
Always get the latest Go CLI version, for your OS

### DIFF
--- a/get-cli.sh
+++ b/get-cli.sh
@@ -1,8 +1,17 @@
-cliVersion=0.1.0
+#!/bin/bash
 
-curl -L https://github.com/openhie/package-starter-kit/releases/download/$cliVersion/gocli-linux -o ./goinstant-linux
-curl -L https://github.com/openhie/package-starter-kit/releases/download/$cliVersion/gocli-macos -o ./goinstant-macos
-curl -L https://github.com/openhie/package-starter-kit/releases/download/$cliVersion/gocli.exe -o ./goinstant.exe
-chmod +x ./goinstant-linux
-chmod +x ./goinstant-macos
-chmod +x ./goinstant.exe
+if [ "$1" == "linux" ]; then
+    curl -L https://github.com/openhie/package-starter-kit/releases/download/latest/gocli-linux -o goinstant
+    chmod +x goinstant
+
+elif [ "$1" == "macos" ]; then
+    curl -L https://github.com/openhie/package-starter-kit/releases/download/latest/gocli-macos -o goinstant
+    chmod +x goinstant
+
+elif [ "$1" == "windows" ]; then
+    curl -L https://github.com/openhie/package-starter-kit/releases/download/latest/gocli.exe -o goinstant.exe
+    chmod +x ./goinstant.exe
+
+else
+    echo 'Usage: ./get-cli.sh "linux|macos|windows"'
+fi


### PR DESCRIPTION
This changes the `get-cli.sh` script always to get the version of the Go CLI tool tagged as "latest" (which is currently version 0.9.0).

It also allows the user to state which OS they want it for, instead of downloading all of them.
