### PR TITLE
Run `apt-get update` otherwise installing unzip will fail

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM openhie/package-base:0.1.0
 # Add default instant OpenHIE packages
 ADD . .
 
-RUN apt-get install -y unzip
+RUN apt-get update && apt-get install -y unzip
 
 # install aws cli - for credential fetching
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"


### PR DESCRIPTION
Docker needs to run `apt-get update` otherwise trying to install the unzip package will result in a 404 error.
